### PR TITLE
fix: fix argument types of vars in the define method

### DIFF
--- a/.changeset/clean-phones-smell.md
+++ b/.changeset/clean-phones-smell.md
@@ -1,0 +1,5 @@
+---
+"@factory-js/factory": patch
+---
+
+Fix argument types of vars in the define method

--- a/packages/factory/src/factory.test.ts
+++ b/packages/factory/src/factory.test.ts
@@ -529,23 +529,24 @@ describe("#factory", () => {
     it("creatse an object with an extended factory", async () => {
       const { props, vars } = factory.define({
         props: {
-          firstName: () => "John",
-          lastName: () => "Doe",
+          name: () => "John",
+          unusedProp: () => "",
         },
         vars: {
           permissions: () => ["read", "write"],
+          unusedVar: () => "",
         },
       }).def;
       const employee = await factory
         .define(
           {
             props: {
-              ...props,
+              name: props.name,
               isAdmin: () => false,
               canRead: later<boolean>(),
             },
             vars: {
-              ...vars,
+              permissions: vars.permissions,
               role: () => "admin",
             },
           },
@@ -558,18 +559,16 @@ describe("#factory", () => {
         })
         .create();
       expect(employee).toStrictEqual({
-        firstName: "John",
-        lastName: "Doe",
+        name: "John",
+        isSaved: true,
         isAdmin: true,
         canRead: true,
-        isSaved: true,
       });
       expectTypeOf(employee).toEqualTypeOf<{
+        name: string;
+        isSaved: boolean;
         isAdmin: boolean;
         canRead: boolean;
-        firstName: string;
-        lastName: string;
-        isSaved: boolean;
       }>();
     });
   });

--- a/packages/factory/src/factory.ts
+++ b/packages/factory/src/factory.ts
@@ -1,6 +1,7 @@
 import type { Create } from "../types/create";
 import type { Deps } from "../types/deps";
 import type { InitProps } from "../types/init-props";
+import type { InitVars } from "../types/init-vars";
 import type { Props } from "../types/props";
 import type { Trait } from "../types/trait";
 import type { TraitSet } from "../types/trait-set";
@@ -17,6 +18,7 @@ class Factory<
   T extends TraitSet<P, V>,
 > {
   readonly #initProps: InitProps<P>;
+  readonly #initVars: InitVars<V>;
   readonly #props: Props<P, V>;
   readonly #vars: Vars<V>;
   readonly #create: Create<P, O>;
@@ -24,18 +26,21 @@ class Factory<
 
   constructor({
     initProps,
+    initVars,
     props,
     vars,
     create,
     traits,
   }: {
     initProps: InitProps<P>;
+    initVars: InitVars<V>;
     props: Props<P, V>;
     vars: Vars<V>;
     create: Create<P, O>;
     traits: T;
   }) {
     this.#initProps = initProps;
+    this.#initVars = initVars;
     this.#props = props;
     this.#vars = vars;
     this.#create = create;
@@ -114,13 +119,14 @@ class Factory<
   get def() {
     return {
       props: this.#initProps,
-      vars: this.#vars,
+      vars: this.#initVars,
     };
   }
 
   get #clone() {
     return {
       initProps: this.#initProps,
+      initVars: this.#initVars,
       props: this.#props,
       create: this.#create,
       traits: this.#traits,
@@ -150,11 +156,12 @@ const define = <
   O = never,
   V extends UnknownRecord = Record<never, never>,
 >(
-  { props, vars }: { props: InitProps<P>; vars: Vars<V> },
+  { props, vars }: { props: InitProps<P>; vars: InitVars<V> },
   create: Create<P, O> = noCreate,
 ) =>
   new Factory({
     initProps: props,
+    initVars: vars,
     traits: {},
     props,
     vars,

--- a/packages/factory/types/init-vars.ts
+++ b/packages/factory/types/init-vars.ts
@@ -1,0 +1,6 @@
+import type { Promisable } from "./promisable";
+import type { UnknownRecord } from "./unknown-record";
+
+export type InitVars<V extends UnknownRecord> = {
+  [K in keyof V]: () => Promisable<V[K]>;
+};


### PR DESCRIPTION
## 📝 Description

Fix the type of vars in `.define` method so that dependency vars cannot be defined within it.

## 🔗 Links

<!--
  Include links to issues or informative sites to review the PR.
  - close: #123
  - https://example.com/
-->

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [x] Add a changeset if it is required.
