### PR TITLE
feat: add function trait and after hooks

### DIFF
--- a/.changeset/serious-monkeys-sell.md
+++ b/.changeset/serious-monkeys-sell.md
@@ -1,0 +1,5 @@
+---
+"@factory-js/factory": minor
+---
+
+Add new features: function trait and after hooks

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -54,6 +54,6 @@
     "lint-staged": "^13.2.1",
     "tsup": "^8.0.2",
     "typescript": "5.2.2",
-    "vitest": "^0.34.4"
+    "vitest": "^1.4.0"
   }
 }

--- a/packages/factory/types/after.ts
+++ b/packages/factory/types/after.ts
@@ -1,0 +1,3 @@
+import type { Promisable } from "./promisable";
+
+export type After<O> = (object: O) => Promisable<void>;

--- a/packages/factory/types/trait-set.ts
+++ b/packages/factory/types/trait-set.ts
@@ -1,7 +1,8 @@
 import type { Trait } from "./trait";
 import type { UnknownRecord } from "./unknown-record";
 
-export type TraitSet<P extends UnknownRecord, V extends UnknownRecord> = Record<
-  string,
-  Trait<P, V>
->;
+export type TraitSet<
+  P extends UnknownRecord,
+  V extends UnknownRecord,
+  O,
+> = Record<string, Trait<P, V, O> | ((...args: never[]) => Trait<P, V, O>)>;

--- a/packages/factory/types/trait.ts
+++ b/packages/factory/types/trait.ts
@@ -1,8 +1,14 @@
+import type { After } from "./after";
 import type { Props } from "./props";
 import type { UnknownRecord } from "./unknown-record";
 import type { Vars } from "./vars";
 
-export type Trait<P extends UnknownRecord, V extends UnknownRecord> = Partial<{
+export type Trait<
+  P extends UnknownRecord,
+  V extends UnknownRecord,
+  O,
+> = Partial<{
   props: Partial<Props<P, V>>;
   vars: Partial<Vars<V>>;
+  after: After<O>;
 }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: ^0.34.4
-        version: 0.34.6(vitest@0.34.6)
+        version: 0.34.6(vitest@1.4.0)
       lint-staged:
         specifier: ^13.2.1
         version: 13.3.0
@@ -71,8 +71,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vitest:
-        specifier: ^0.34.4
-        version: 0.34.6
+        specifier: ^1.4.0
+        version: 1.4.0
 
   packages/prisma-factory:
     dependencies:
@@ -1751,6 +1751,30 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/coverage-v8@0.34.6(vitest@1.4.0):
+    resolution:
+      {
+        integrity: sha512-fivy/OK2d/EsJFoEoxHFEnNGTg+MmdZBAVK9Ka4qhXR2K3J0DS08vcGVwzDtXSuUMabLv4KtPcpSKkcMXFDViw==,
+      }
+    peerDependencies:
+      vitest: ">=0.32.0 <1"
+    dependencies:
+      "@ampproject/remapping": 2.2.1
+      "@bcoe/v8-coverage": 0.2.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.7
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.2.0
+      vitest: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitest/expect@0.34.6:
     resolution:
       {
@@ -1759,6 +1783,17 @@ packages:
     dependencies:
       "@vitest/spy": 0.34.6
       "@vitest/utils": 0.34.6
+      chai: 4.4.1
+    dev: true
+
+  /@vitest/expect@1.4.0:
+    resolution:
+      {
+        integrity: sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==,
+      }
+    dependencies:
+      "@vitest/spy": 1.4.0
+      "@vitest/utils": 1.4.0
       chai: 4.4.1
     dev: true
 
@@ -1773,10 +1808,32 @@ packages:
       pathe: 1.1.2
     dev: true
 
+  /@vitest/runner@1.4.0:
+    resolution:
+      {
+        integrity: sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==,
+      }
+    dependencies:
+      "@vitest/utils": 1.4.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
   /@vitest/snapshot@0.34.6:
     resolution:
       {
         integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==,
+      }
+    dependencies:
+      magic-string: 0.30.7
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/snapshot@1.4.0:
+    resolution:
+      {
+        integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==,
       }
     dependencies:
       magic-string: 0.30.7
@@ -1793,6 +1850,15 @@ packages:
       tinyspy: 2.2.1
     dev: true
 
+  /@vitest/spy@1.4.0:
+    resolution:
+      {
+        integrity: sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==,
+      }
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
   /@vitest/utils@0.34.6:
     resolution:
       {
@@ -1800,6 +1866,18 @@ packages:
       }
     dependencies:
       diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/utils@1.4.0:
+    resolution:
+      {
+        integrity: sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==,
+      }
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
@@ -3203,6 +3281,15 @@ packages:
     engines: { node: ">=4.0" }
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+    dependencies:
+      "@types/estree": 1.0.5
+    dev: true
+
   /esutils@2.0.3:
     resolution:
       {
@@ -3251,6 +3338,24 @@ packages:
       npm-run-path: 5.2.0
       onetime: 6.0.0
       signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
+
+  /execa@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==,
+      }
+    engines: { node: ">=16.17" }
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.2.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
       strip-final-newline: 3.0.0
     dev: true
 
@@ -3512,6 +3617,14 @@ packages:
         integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
       }
     engines: { node: ">=10" }
+    dev: true
+
+  /get-stream@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==,
+      }
+    engines: { node: ">=16" }
     dev: true
 
   /get-symbol-description@1.0.2:
@@ -3785,6 +3898,14 @@ packages:
         integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==,
       }
     engines: { node: ">=14.18.0" }
+    dev: true
+
+  /human-signals@5.0.0:
+    resolution:
+      {
+        integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==,
+      }
+    engines: { node: ">=16.17.0" }
     dev: true
 
   /husky@9.0.11:
@@ -4226,6 +4347,13 @@ packages:
       }
     dev: true
 
+  /js-tokens@8.0.3:
+    resolution:
+      {
+        integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==,
+      }
+    dev: true
+
   /js-yaml@3.14.1:
     resolution:
       {
@@ -4470,6 +4598,17 @@ packages:
         integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==,
       }
     engines: { node: ">=14" }
+    dev: true
+
+  /local-pkg@0.5.0:
+    resolution:
+      {
+        integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==,
+      }
+    engines: { node: ">=14" }
+    dependencies:
+      mlly: 1.5.0
+      pkg-types: 1.0.3
     dev: true
 
   /locate-path@5.0.0:
@@ -5028,6 +5167,16 @@ packages:
         integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
+  /p-limit@5.0.0:
+    resolution:
+      {
+        integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==,
+      }
+    engines: { node: ">=18" }
     dependencies:
       yocto-queue: 1.0.0
     dev: true
@@ -6146,6 +6295,15 @@ packages:
       acorn: 8.11.3
     dev: true
 
+  /strip-literal@2.0.0:
+    resolution:
+      {
+        integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==,
+      }
+    dependencies:
+      js-tokens: 8.0.3
+    dev: true
+
   /structured-source@4.0.0:
     resolution:
       {
@@ -6309,6 +6467,14 @@ packages:
     resolution:
       {
         integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==,
+      }
+    engines: { node: ">=14.0.0" }
+    dev: true
+
+  /tinypool@0.8.2:
+    resolution:
+      {
+        integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==,
       }
     engines: { node: ">=14.0.0" }
     dev: true
@@ -6838,6 +7004,30 @@ packages:
       - terser
     dev: true
 
+  /vite-node@1.4.0:
+    resolution:
+      {
+        integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.1.3(@types/node@20.11.19)
+    transitivePeerDependencies:
+      - "@types/node"
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite@5.1.3(@types/node@20.11.19):
     resolution:
       {
@@ -6934,6 +7124,64 @@ packages:
       tinypool: 0.7.0
       vite: 5.1.3(@types/node@20.11.19)
       vite-node: 0.34.6(@types/node@20.11.19)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.4.0:
+    resolution:
+      {
+        integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@types/node": ^18.0.0 || >=20.0.0
+      "@vitest/browser": 1.4.0
+      "@vitest/ui": 1.4.0
+      happy-dom: "*"
+      jsdom: "*"
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      "@vitest/expect": 1.4.0
+      "@vitest/runner": 1.4.0
+      "@vitest/snapshot": 1.4.0
+      "@vitest/spy": 1.4.0
+      "@vitest/utils": 1.4.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.7
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.0.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.1.3(@types/node@20.11.19)
+      vite-node: 1.4.0
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## 📝 Description

Add new features: function trait and after hooks.
The most common use case involves creating M:N models, like this:

```typescript
import { randSequence } from "@ngneat/falso";

const categoryFactory = factory
  .define(
    {
      props: {
        name: () => randSequence({ size: 40 }),
      },
      vars: {},
    },
    (props) => create(categories, props),
  )
  .traits({
    withPost: (post: Post) => ({
      after: async (category) => {
        // Create a junction table between the "post" and "category" tables.
        await categoriesOnPostsFactory
          .vars({ post: () => post, category: () => category })
          .create();
      },
    }),
  });

const post = await postFactory.create();
const category = await categoryFactory.use((t) => t.withPost(post)).create();
```

## 🔗 Links

<!--
  Include links to issues or informative sites to review the PR.
  - close: #123
  - https://example.com/
-->

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [x] Add a changeset if it is required.
