### PR TITLE
fix: export the factory class type

### DIFF
--- a/.changeset/cool-coins-decide.md
+++ b/.changeset/cool-coins-decide.md
@@ -1,0 +1,5 @@
+---
+"@factory-js/factory": patch
+---
+
+Export the factory class type

--- a/packages/factory/src/factory.ts
+++ b/packages/factory/src/factory.ts
@@ -12,7 +12,7 @@ import { mapValues } from "./utils/map-values";
 import { mapValuesAsync } from "./utils/map-values-async";
 import { proxyDeps } from "./utils/proxy-deps";
 
-class Factory<
+export class Factory<
   P extends UnknownRecord,
   O,
   V extends UnknownRecord,

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -1,2 +1,4 @@
+export type { Factory } from "./factory";
+
 export { later } from "./helpers/later";
 export { factory } from "./factory";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "resolveJsonModule": true,
     "incremental": false,
     "allowJs": false,
-    "checkJs": false
+    "checkJs": false,
+    "declaration": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📝 Description
This PR makes the Factory class type importable to fix [the maximum length error](https://stackoverflow.com/questions/68463963/typescript-the-inferred-type-of-this-node-exceeds-the-maximum-length-the-compi) that occurs when a factory has many properties.

TypeScript tries to infer the result type without using the Factory type because this type is not exported, and it eventually throws a maximum length error as the result type is complicated.

This type error occurs only when `declaration` options is true.


## 🔗 Links

<!--
  Include links to issues or informative sites to review the PR.
  - close: #123
  - https://example.com/
-->
- https://stackoverflow.com/questions/68463963/typescript-the-inferred-type-of-this-node-exceeds-the-maximum-length-the-compi

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [x] Add a changeset if it is required.
