### PR TITLE
Add prismaClientModule option to config

### DIFF
--- a/packages/prisma-factory/src/generator/content-writer.test.ts
+++ b/packages/prisma-factory/src/generator/content-writer.test.ts
@@ -18,13 +18,18 @@ describe("ContentWriter", () => {
       const { enums, models } = dmmf.datamodel;
       const value = removeIndents(
         await format(
-          new ContentWriter({ enums, models, randModule: "rands" }).write(),
+          new ContentWriter({
+            enums,
+            models,
+            randModule: "rands",
+            prismaClientModule: "example/path/to/prisma/client",
+          }).write(),
         ),
       );
       expect(value).toMatch(
         removeIndents(`
           import { factory } from "@factory-js/factory";
-          import type { Prisma, PrismaClient } from "@prisma/client";
+          import type { Prisma, PrismaClient } from "example/path/to/prisma/client";
           import { rands } from "rands";
         `),
       );

--- a/packages/prisma-factory/src/generator/content-writer.ts
+++ b/packages/prisma-factory/src/generator/content-writer.ts
@@ -6,25 +6,29 @@ export class ContentWriter {
   readonly #enums: ReadonlyDeep<DMMF.DatamodelEnum[]>;
   readonly #models: ReadonlyDeep<DMMF.Model[]>;
   readonly #randModule: string;
+  readonly #prismaClientModule: string;
 
   constructor({
     enums,
     models,
     randModule,
+    prismaClientModule,
   }: {
     enums: ReadonlyDeep<DMMF.DatamodelEnum[]>;
     models: ReadonlyDeep<DMMF.Model[]>;
     randModule: string;
+    prismaClientModule: string;
   }) {
     this.#enums = enums;
     this.#models = models;
     this.#randModule = randModule;
+    this.#prismaClientModule = prismaClientModule;
   }
 
   write() {
     return `
       import { factory } from "@factory-js/factory";
-      import type { Prisma, PrismaClient } from "@prisma/client";
+      import type { Prisma, PrismaClient } from "${this.#prismaClientModule}";
       import { rands } from "${this.#randModule}";
       ${this.#enums.map((enumValue) => new EnumWriter(enumValue).write()).join("\n")}
       ${this.#models.map((model) => new FactoryWriter(model).write()).join("\n")}

--- a/packages/prisma-factory/src/generator/index.ts
+++ b/packages/prisma-factory/src/generator/index.ts
@@ -7,6 +7,7 @@ import { ContentWriter } from "./content-writer.js";
 
 const DEFAULT_OUTPUT_DIR = "./generated";
 const DEFAULT_RAND_MODULE = "@factory-js/prisma-factory";
+const DEFAULT_PRISMA_CLIENT_MODULE = "@prisma/client";
 
 const writeFileSafely = async (filePath: string, value: string) => {
   const formatted = await prettier.format(value, { parser: "typescript" });
@@ -16,6 +17,14 @@ const writeFileSafely = async (filePath: string, value: string) => {
 
 const getRandModule = (randsPath: string | string[] | undefined) => {
   return typeof randsPath === "string" ? randsPath : DEFAULT_RAND_MODULE;
+};
+
+const getPrismaClientModule = (
+  prismaClientPath: string | string[] | undefined,
+) => {
+  return typeof prismaClientPath === "string"
+    ? prismaClientPath
+    : DEFAULT_PRISMA_CLIENT_MODULE;
 };
 
 generatorHandler({
@@ -29,10 +38,18 @@ generatorHandler({
     const { models, enums } = options.dmmf.datamodel;
     const { config, output } = options.generator;
     const randModule = getRandModule(config["randModule"]);
+    const prismaClientModule = getPrismaClientModule(
+      config["prismaClientModule"],
+    );
 
     await writeFileSafely(
       path.join(output?.value ?? DEFAULT_OUTPUT_DIR, "factories.ts"),
-      new ContentWriter({ enums, models, randModule }).write(),
+      new ContentWriter({
+        enums,
+        models,
+        randModule,
+        prismaClientModule,
+      }).write(),
     );
   },
 });


### PR DESCRIPTION
## 📝 Description

In my product, I changed the output option of the generator client config in my schema.prisma to `output = "./path/to/client"`. However, in factories.ts, the import path for Prisma and PrismaClient is still `"@prisma/client"`, and it can't find the module. It should locate my `./path/to/client` module. I resolved this issue by adding the `prismaClientModule` config to the generator factory config.

Thank you for the great library!

## 🔗 Links

na

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [-] Add a changeset if it is required.
