### PR TITLE
feat: add the seq function

### DIFF
--- a/.changeset/tall-terms-repair.md
+++ b/.changeset/tall-terms-repair.md
@@ -1,0 +1,5 @@
+---
+"@factory-js/factory": minor
+---
+
+feat: add the seq function

--- a/packages/factory/src/helpers/seq.test.ts
+++ b/packages/factory/src/helpers/seq.test.ts
@@ -1,0 +1,33 @@
+import { expect, it, describe } from "vitest";
+import { seq } from "..";
+
+describe("#seq", () => {
+  describe("when an iteratee is called multiple times", () => {
+    it("increments a count and returns a value", async () => {
+      const count = seq(1, (count) =>
+        Promise.resolve(`count: ${count.toString()}`),
+      );
+      await expect(count()).resolves.toBe("count: 1");
+      await expect(count()).resolves.toBe("count: 2");
+      await expect(count()).resolves.toBe("count: 3");
+    });
+  });
+
+  describe("when it is used multiple times", () => {
+    it("has an independent count", () => {
+      const count1 = seq(1, (count) => `count1: ${count.toString()}`);
+      const count2 = seq(1, (count) => `count2: ${count.toString()}`);
+      expect(count1()).toBe("count1: 1");
+      expect(count2()).toBe("count2: 1");
+    });
+  });
+
+  describe("when an iteratee has an additional argument", () => {
+    it("accepts the argument", async () => {
+      const count = seq(1, (count, label: string) =>
+        Promise.resolve(`${label}: ${count.toString()}`),
+      );
+      await expect(count("label")).resolves.toBe("label: 1");
+    });
+  });
+});

--- a/packages/factory/src/helpers/seq.ts
+++ b/packages/factory/src/helpers/seq.ts
@@ -1,0 +1,14 @@
+import type { Promisable } from "../../types/promisable";
+
+type Iteratee<A extends unknown[], O> = (
+  count: number,
+  ...args: A
+) => Promisable<O>;
+
+export const seq = <A extends unknown[], O>(
+  initialCount: number,
+  iteratee: Iteratee<A, O>,
+) => {
+  let count = initialCount;
+  return (...args: A) => iteratee(count++, ...args);
+};

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -1,4 +1,5 @@
 export type { Factory } from "./factory";
 
 export { later } from "./helpers/later";
+export { seq } from "./helpers/seq";
 export { factory } from "./factory";


### PR DESCRIPTION
## 📝 Description

This is the revert of this [this PR](https://github.com/factory-js/factory-js/pull/17). The `seq` function is still beneficial in terms of generating sequential numbers, and we can use the function to avoid UNIQUE constraint errors by combining it with  [WORKER_ID](https://vitest.dev/guide/migration.html#envs).

## 🔗 Links

<!--
  Include links to issues or informative sites to review the PR.
  - close: #123
  - https://example.com/
-->
- close: https://github.com/factory-js/factory-js/issues/68
- https://github.com/orgs/factory-js/discussions/28

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [x] Add a changeset if it is required.
