### PR TITLE
fix: support the strictUndefinedChecks option

### DIFF
--- a/.changeset/honest-pianos-attack.md
+++ b/.changeset/honest-pianos-attack.md
@@ -1,0 +1,5 @@
+---
+"@factory-js/prisma-factory": patch
+---
+
+fix: support the strictUndefinedChecks option

--- a/packages/prisma-factory/e2e/schema.prisma
+++ b/packages/prisma-factory/e2e/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["strictUndefinedChecks"]
 }
 
 generator factory {

--- a/packages/prisma-factory/src/generator/factory-writer.test.ts
+++ b/packages/prisma-factory/src/generator/factory-writer.test.ts
@@ -151,7 +151,7 @@ describe("FactoryWriter", () => {
       );
       expect(value).toMatch(
         removeIndents(
-          ".props({ userId: async ({ vars }) => (await vars.user)?.id })",
+          ".props({ userId: async ({ vars }) => (await vars.user)?.id ?? null })",
         ),
       );
     });

--- a/packages/prisma-factory/src/generator/factory-writer.ts
+++ b/packages/prisma-factory/src/generator/factory-writer.ts
@@ -61,7 +61,7 @@ export class FactoryWriter {
     return (field.relationFromFields ?? [])
       .map((fieldName, index) => {
         const relationToField = field.relationToFields?.[index] ?? "";
-        return `${fieldName}: async ({ vars }) => (await vars.${field.name})${field.isRequired ? "" : "?"}.${relationToField}`;
+        return `${fieldName}: async ({ vars }) => (await vars.${field.name})${field.isRequired ? "" : "?"}.${relationToField}${!field.isRequired ? " ?? null" : ""}`;
       })
       .join(",");
   }


### PR DESCRIPTION
## 📝 Description

Prisma client disallows `undefined` when [strictUndefinedChecks](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined#strict-undefined-checks-preview-feature) is enabled. However, prisma-factory returns `undefined` when a model has self-relation.  This PR fixes this issue by returning `null` instead.

## 🔗 Links

<!--
  Include links to issues or informative sites to review the PR.
  - close: #123
  - https://example.com/
-->

## ✅ Checklist

<!-- Refer to Contributing guide and make sure to complete the checklist -->

- [x] Run tests and linters.
- [x] Add a changeset if it is required.
